### PR TITLE
Added feature to handle NSFW content

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,4 +1,5 @@
 import {createStyles} from '@mantine/core'
+import {useRedditContext} from '~/components/RedditProvider'
 import {Post} from '~/lib/types'
 
 const useStyles = createStyles((theme) => ({
@@ -13,6 +14,11 @@ const useStyles = createStyles((theme) => ({
   video: {
     height: 'auto',
     width: '100%'
+  },
+  blurred: {
+    height: 'auto',
+    width: '100%',
+    filter: 'blur(8px)'
   }
 }))
 
@@ -21,6 +27,7 @@ const useStyles = createStyles((theme) => ({
  */
 export default function Card(props: Post) {
   const {classes} = useStyles()
+  const {blurNSFW} = useRedditContext()
   return (
     <div className={classes.card}>
       {(() => {
@@ -30,7 +37,9 @@ export default function Card(props: Post) {
               <a href={props?.permalink}>
                 <img
                   alt={props?.title}
-                  className={classes.image}
+                  className={
+                    props.over_18 && blurNSFW ? classes.blurred : classes.image
+                  }
                   data-hint="image"
                   height={props?.images?.height}
                   loading="lazy"
@@ -42,7 +51,9 @@ export default function Card(props: Post) {
           case 'hosted:video':
             return (
               <video
-                className={classes.video}
+                className={
+                  props.over_18 && blurNSFW ? classes.blurred : classes.video
+                }
                 controls
                 crossOrigin="anonymous"
                 data-hint="hosted:video"
@@ -60,7 +71,9 @@ export default function Card(props: Post) {
           case 'rich:video':
             return props?.video_preview ? (
               <video
-                className={classes.video}
+                className={
+                  props.over_18 && blurNSFW ? classes.blurred : classes.video
+                }
                 controls
                 crossOrigin="anonymous"
                 data-hint="rich:video"
@@ -98,7 +111,9 @@ export default function Card(props: Post) {
             if (props?.url.includes('gifv')) {
               return (
                 <video
-                  className={classes.video}
+                  className={
+                    props.over_18 && blurNSFW ? classes.blurred : classes.video
+                  }
                   controls
                   data-hint="link"
                   muted

--- a/components/RedditProvider.tsx
+++ b/components/RedditProvider.tsx
@@ -1,14 +1,17 @@
-import { createContext, useContext, useState } from 'react'
+import {useLocalStorage} from '@mantine/hooks'
+import {createContext, useContext, useState} from 'react'
 import config from '~/lib/config'
-import { ChildrenProps } from '~/lib/types'
+import {ChildrenProps} from '~/lib/types'
 
 export interface RedditProviderProps {
   sort: string
   subReddit: any
   setSort: (sort: string) => void
   setSubreddit: (subReddit: {}) => void
-  searchInput: (string)
+  searchInput: string
   setSearchInput: (searchInput: string) => void
+  blurNSFW: boolean
+  setBlurNSFW: (blur: boolean) => void
 }
 
 // Create the RedditContext.
@@ -28,6 +31,10 @@ export default function RedditProvider({children}: ChildrenProps) {
   const [sort, setSort] = useState(config.redditApi.sort)
   const [subReddit, setSubreddit] = useState(config.redditApi.subReddit)
   const [searchInput, setSearchInput] = useState('')
+  const [blurNSFW, setBlurNSFW] = useLocalStorage({
+    key: 'nsfwblur',
+    defaultValue: true
+  })
 
   // Set the global state.
   const providerValues = {
@@ -36,7 +43,9 @@ export default function RedditProvider({children}: ChildrenProps) {
     setSort,
     sort,
     searchInput,
-    setSearchInput
+    setSearchInput,
+    blurNSFW,
+    setBlurNSFW
   }
 
   return (

--- a/components/Results.tsx
+++ b/components/Results.tsx
@@ -31,7 +31,8 @@ const useStyles = createStyles((theme) => ({
 /**
  * Results component.
  */
-export default function Results() {
+export default function Results(props) {
+  const {blurNSFW} = props
   const {subReddit, sort} = useRedditContext()
   const {classes} = useStyles()
   const [loading, setLoading] = useState(true)
@@ -104,7 +105,7 @@ export default function Results() {
         className={classes.masonry}
       >
         {posts.map((post) => (
-          <Card key={post.id} {...post} />
+          <Card key={post.id} {...post} blurNSFW={blurNSFW} />
         ))}
       </Masonry>
       <Button className={classes.loadMore} ref={ref} onClick={infiniteScroll}>

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -1,6 +1,13 @@
-import {Autocomplete, createStyles} from '@mantine/core'
+import {
+  Autocomplete,
+  Badge,
+  createStyles,
+  Group,
+  SelectItemProps
+} from '@mantine/core'
 import {useDebouncedValue} from '@mantine/hooks'
 import {IconSearch} from '@tabler/icons'
+import {forwardRef} from 'react'
 import useSWR from 'swr'
 import {useRedditContext} from '~/components/RedditProvider'
 import {fetcher} from '~/lib/helpers'
@@ -10,6 +17,22 @@ const useStyles = createStyles(() => ({
     width: '100%'
   }
 }))
+
+interface ItemProps extends SelectItemProps {
+  over18: string
+}
+
+const AutoCompleteItem = forwardRef<HTMLDivElement, ItemProps>(
+  ({value, over18, ...others}: ItemProps, ref) => (
+    <div ref={ref} {...others}>
+      <Group noWrap position={'apart'}>
+        {value}
+        {over18.toLowerCase() === 'true' && <Badge color="red">NSFW</Badge>}
+      </Group>
+    </div>
+  )
+)
+AutoCompleteItem.displayName = 'AutoCompleteItem'
 
 /**
  * Search component.
@@ -43,6 +66,7 @@ export default function Search() {
       placeholder="Search for a sub"
       size="lg"
       value={searchInput}
+      itemComponent={AutoCompleteItem}
     />
   )
 }

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -8,15 +8,22 @@ import {
 } from '@mantine/core'
 import {IconSettings} from '@tabler/icons'
 import {useState} from 'react'
+import {useRedditContext} from '~/components/RedditProvider'
 
 const useStyles = createStyles(() => ({
-  settings: {}
+  settings: {},
+  swtich: {
+    ':not(:last-of-type)': {
+      marginBottom: '0.5rem'
+    }
+  }
 }))
 
 export default function Settings() {
   const {classes} = useStyles()
   const [opened, setOpened] = useState(false)
   const {colorScheme, toggleColorScheme} = useMantineColorScheme()
+  const {blurNSFW, setBlurNSFW} = useRedditContext()
 
   return (
     <>
@@ -29,6 +36,17 @@ export default function Settings() {
           onChange={() => toggleColorScheme()}
           onLabel="ON"
           size="lg"
+          className={classes.swtich}
+        />
+        <Switch
+          aria-label="Blue NSFW images."
+          label="Blur NSFW images."
+          checked={blurNSFW}
+          offLabel="OFF"
+          onChange={(event) => setBlurNSFW(event.currentTarget.checked)}
+          onLabel="ON"
+          size="lg"
+          className={classes.swtich}
         />
       </Modal>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import {createStyles} from '@mantine/core'
+import {useState} from 'react'
 import BackToTop from '~/components/BackToTop'
 import Footer from '~/components/Footer'
 import Header from '~/components/Header'


### PR DESCRIPTION
Closes #390

### Description

Added NSFW badge to Serach component for results with over18
Added blur on NFSW images and videos
Added settings for blurring NSFW images or not

### Screenshot

![image](https://user-images.githubusercontent.com/14825674/194604884-41e55fa3-ac81-428e-8242-7eb9176730ed.png)
![image](https://user-images.githubusercontent.com/14825674/194604967-c5fe86f1-44e6-454e-8489-f846524bc0c3.png)

I'd rather not post screenshots of the NSFW blur.

### Verification

1. In a search bar enter a search text that has both NSFW and regular subreddits.
2. Badge should show
3.  Select a NSFW subreddit
4. Imaged should be blurred
5. Select the cogwheel, turn off blur NSFW images
6. Images and videos should no longer be blurred

This could be improved with a state library probably in another issue.