### PR TITLE
Ensure settings toggles have accessible labels

### DIFF
--- a/components/Settings/Settings.tsx
+++ b/components/Settings/Settings.tsx
@@ -47,6 +47,7 @@ export function Settings() {
 
         <Menu.Item closeMenuOnClick={false}>
           <Switch
+            aria-label="Allow NSFW"
             label="Allow NSFW"
             checked={nsfw}
             onChange={() => dispatch(toggleNsfw())}
@@ -55,6 +56,7 @@ export function Settings() {
 
         <Menu.Item closeMenuOnClick={false}>
           <Switch
+            aria-label="Dark Mode"
             label="Dark Mode"
             checked={isDark}
             onChange={(e) =>
@@ -65,6 +67,7 @@ export function Settings() {
 
         <Menu.Item closeMenuOnClick={false}>
           <Switch
+            aria-label="Mute"
             label="Mute"
             checked={isMuted}
             onChange={() => dispatch(toggleMute())}


### PR DESCRIPTION
## Summary
- add `aria-label`s to NSFW, dark mode, and mute switches so they can be queried by label

## Testing
- `npm test components/Settings/Settings.test.tsx -- --run`
- `npm run lint components/Settings/Settings.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6acfbb48320958ca2dbc3eae4cb