### PR TITLE
feat(postcard): add datetime to post time

### DIFF
--- a/components/PostCard/PostCard.test.tsx
+++ b/components/PostCard/PostCard.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@/lib/utils/getMediumImage', () => ({
 }))
 
 describe('PostCard', () => {
-  it('renders post information', () => {
+  it('should render post information', () => {
     const post: any = {
       id: '1',
       subreddit_name_prefixed: 'r/test',
@@ -25,9 +25,35 @@ describe('PostCard', () => {
       ups: 10,
       num_comments: 2
     }
+
     render(<PostCard post={post} />)
+
     expect(screen.getByRole('heading', {name: 'Test post'})).toBeInTheDocument()
     expect(screen.getByText(/r\/test/)).toBeInTheDocument()
-    expect(screen.getByText('just now')).toBeInTheDocument()
+
+    const time = screen.getByText('just now')
+    expect(time).toBeInTheDocument()
+    expect(time).toHaveAttribute(
+      'dateTime',
+      new Date(post.created_utc * 1000).toISOString()
+    )
+  })
+
+  it('should render empty time when created_utc is missing', () => {
+    const post: any = {
+      id: '1',
+      subreddit_name_prefixed: 'r/test',
+      permalink: '/r/test/1',
+      title: 'Test post',
+      preview: {images: [{resolutions: []}]},
+      ups: 10,
+      num_comments: 2
+    }
+
+    render(<PostCard post={post} />)
+
+    const time = screen.getByText((_, element) => element.tagName === 'TIME')
+    expect(time).toBeInTheDocument()
+    expect(time).toHaveAttribute('dateTime', '')
   })
 })

--- a/components/PostCard/PostCard.tsx
+++ b/components/PostCard/PostCard.tsx
@@ -15,6 +15,9 @@ export function PostCard({post}: Readonly<PostCardProps>) {
   const preview = post.preview?.images?.[0]?.resolutions
   const image = getMediumImage(preview ?? [])
   const postLink = `https://reddit.com${post.permalink}`
+  const created = post.created_utc
+    ? new Date(post.created_utc * 1000).toISOString()
+    : ''
 
   return (
     <Card
@@ -29,7 +32,7 @@ export function PostCard({post}: Readonly<PostCardProps>) {
         <a href={`/${post.subreddit_name_prefixed}`}>
           <Text size="sm" c="dimmed">
             {post.subreddit_name_prefixed} &middot;{' '}
-            <time>
+            <time dateTime={created}>
               {post.created_utc ? formatTimeAgo(post.created_utc) : ''}
             </time>
           </Text>


### PR DESCRIPTION
## Summary
- compute ISO string for post creation
- expose created time with `<time dateTime>`
- test time rendering with and without timestamp

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c2e0bd7a708320a2c3143a76614893