### PR TITLE
hotfix: temporarily bypass origin validation in production

### DIFF
--- a/lib/utils/validateOrigin.ts
+++ b/lib/utils/validateOrigin.ts
@@ -57,6 +57,10 @@ export function validateOrigin(request: NextRequest): boolean {
     return true
   }
 
+  // TEMPORARY HOT FIX: Allow all origins in production until environment variables are properly configured
+  // TODO: Remove this after fixing environment variable configuration
+  return true
+
   // Production mode allows specific localhost patterns only
   // (useful for Docker, CI/CD, local production testing)
   const localhostPattern =


### PR DESCRIPTION
App is down due to origin validation blocking all requests. The COOLIFY_FQDN environment variable mismatch is causing legitimate requests to be blocked.

This hotfix temporarily allows all origins in production to restore service immediately.

TODO: Investigate why COOLIFY_FQDN=reddit-viewer.com is not being set (when it should be automatically) and remove this bypass.
